### PR TITLE
Override curations_concerns FileSet views presuming existence of parent

### DIFF
--- a/app/controllers/storage_controller_behavior.rb
+++ b/app/controllers/storage_controller_behavior.rb
@@ -51,7 +51,7 @@ module StorageControllerBehavior
   end
 
   def filename
-    @filename ||= File.basename(file_set_solr_document['filename_tesim'].first)
+    @filename ||= File.basename(file_set_solr_document['filename_tesim']&.first.to_s)
   end
 
   def get_file_status

--- a/app/views/curation_concerns/file_sets/_form.html.erb
+++ b/app/views/curation_concerns/file_sets/_form.html.erb
@@ -1,0 +1,39 @@
+<%= simple_form_for [main_app, curation_concern],
+                    html: { multipart: true },
+                    wrapper_mappings: { multifile: :horizontal_file_input } do |f| %>
+  <div class="row">
+    <div class="col-md-6">
+      <fieldset class="required">
+        <legend>Your File&#8217;s Title</legend>
+        <span class="control-label">
+          <%= label_tag 'file_set[title][]', 'Title',  class: "string optional" %>
+        </span>
+        <%= text_field_tag 'file_set[title][]', curation_concern.title.first, class: 'form-control' %>
+      </fieldset>
+      <fieldset class="required">
+        <legend>
+          Attach Your File
+        </legend>
+        <%= f.input :files, as: :multifile %>
+      </fieldset>
+    </div>
+
+    <div class="col-md-6">
+      <%= render "form_permission", f: f %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-md-12 form-actions">
+      <%= f.submit(
+        (curation_concern.persisted? ? "Update Attached File" : %(Attach to #{parent.human_readable_type})),
+        class: 'btn btn-primary'
+      ) %>
+      <% if parent %>
+        <%= link_to 'Cancel', parent_path(parent), class: 'btn btn-link' %>
+      <% else %>
+        <%= link_to 'Cancel', polymorphic_path([main_app, curation_concern]), class: 'btn btn-link'  %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/curation_concerns/file_sets/edit.html.erb
+++ b/app/views/curation_concerns/file_sets/edit.html.erb
@@ -1,0 +1,9 @@
+<% provide :page_title, curation_concern_page_title(curation_concern) %>
+<% provide :page_header do %>
+  <% if parent %>
+    <h1>Updating Attached File to <span class="parent_container">"<%= parent %>"<span></h1>
+  <% else %>
+    <h1>Updating FileSet</h1>
+  <% end %>
+<% end %>
+<%= render 'form' %>


### PR DESCRIPTION
* Handles case of no filename specified
* Allows FileSet edit form to render without error

It seems that curation_concerns makes the assumption -- at least, in the two views that I copied over and modified -- that a FileSet will have a parent.  We may want to more thoroughly review all places where that assumption is made.