### PR TITLE
Added testing gems, FileSetsController tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,133 @@
+require: rubocop-rspec
+
+AllCops:
+  TargetRubyVersion: 2.3
+  RunRailsCops: true
+  DisplayCopNames: true
+  Include:
+    - '**/Rakefile'
+    - '**/config.ru'
+  Exclude:
+    - 'db/**/*'
+    - 'script/**/*'
+    - 'vendor/**/*'
+    - 'bin/*'
+    - 'config/deploy.rb'
+
+Rails:
+  Enabled: true
+
+Lint/UnusedBlockArgument:
+  Exclude:
+    - 'config/initializers/hydra_config.rb'
+    - 'spec/**/*'
+
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/ClassLength:
+  Exclude:
+    - 'app/controllers/catalog_controller.rb'
+
+Metrics/MethodLength:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Exclude:
+    - 'spec/**/*'
+
+Style/SymbolProc:
+  Exclude:
+    - 'spec/factories/**/*'
+
+Style/BlockComments:
+  Exclude:
+    - 'spec/spec_helper.rb'
+
+Style/BlockEndNewline:
+  Exclude:
+    - 'spec/**/*'
+
+Style/IndentHash:
+  Exclude:
+    - 'app/controllers/catalog_controller.rb'
+
+Style/LeadingCommentSpace:
+  Exclude:
+    - 'spec/**/*'
+
+Style/MultilineBlockLayout:
+  Exclude:
+    - 'spec/**/*'
+
+
+Style/IndentationConsistency:
+  EnforcedStyle: rails
+
+Style/CollectionMethods:
+  PreferredMethods:
+    collect: 'map'
+    collect!: 'map!'
+    inject: 'reduce'
+    detect: 'find'
+    find_all: 'select'
+
+Style/GlobalVars:
+  Exclude:
+    - 'config/initializers/redis_config.rb'
+
+Style/WordArray:
+  Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/SingleLineBlockParams:
+  Enabled: false
+
+Style/SignalException:
+  Enabled: false
+
+Rails/Date:
+  Enabled: false
+
+Rails/TimeZone:
+  Enabled: false
+
+RSpec/ExampleWording:
+  CustomTransform:
+    be: is
+    have: has
+    not: does not
+    NOT: does NOT
+  IgnoredWords:
+    - only
+
+RSpec/FilePath:
+  Enabled: false
+
+RSpec/InstanceVariable:
+  Enabled: false
+
+RSpec/DescribeClass:
+  Exclude:
+    - 'spec/javascripts/jasmine_spec.rb'
+    - 'spec/tasks/rake_spec.rb'
+    - 'spec/jobs/event_jobs_spec.rb'
+    - 'spec/abilities/**/*'
+    - 'spec/features/**/*'
+    - 'spec/views/**/*'
+    - 'spec/routing/**/*'
+    - 'spec/inputs/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,13 @@ group :development, :test do
   gem 'capybara'
   gem 'webmock'
   gem 'coveralls', require: false
+  gem 'factory_girl_rails'
+  gem 'rails-controller-testing'
+  gem 'guard-rspec', require: false
+  gem 'guard-rubocop', require: false
+  gem 'rubocop', '~> 0.34.0', require: false
+  gem 'rubocop-rspec', '~> 1.3.0', require: false
+  gem 'simplecov', require: false
 end
 
 gem 'curation_concerns', '~> 1.6.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,9 @@ GEM
       rails (>= 4.2, < 6)
     archive-tar-minitar (0.5.2)
     arel (7.1.4)
+    ast (2.3.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
     autoprefixer-rails (6.7.6)
       execjs
     awesome_nested_set (3.1.1)
@@ -214,12 +217,19 @@ GEM
       sxp (~> 1.0)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_girl (4.8.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.8.0)
+      factory_girl (~> 4.8.0)
+      railties (>= 3.0.0)
     faraday (0.10.1)
       multipart-post (>= 1.2, < 3)
     fcrepo_wrapper (0.8.0)
       ruby-progressbar
+    ffi (1.9.17)
     font-awesome-rails (4.7.0.1)
       railties (>= 3.2, < 5.1)
+    formatador (0.2.5)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     google-api-client (0.10.0)
@@ -243,6 +253,23 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
+    guard (2.14.1)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (~> 1.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
+    guard-rubocop (1.2.0)
+      guard (~> 2.0)
+      rubocop (~> 0.20)
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashdiff (0.3.2)
@@ -326,12 +353,17 @@ GEM
       slop
     libv8 (3.16.14.17)
     link_header (0.0.8)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
     little-plugger (1.1.4)
     logging (2.1.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
+    lumberjack (1.0.11)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     memoist (0.15.0)
@@ -346,10 +378,14 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    nenv (0.3.0)
     nio4r (2.0.0)
     noid (0.9.0)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
+    notiffany (0.1.1)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
     oauth2 (1.3.0)
       faraday (>= 0.8, < 0.11)
       jwt (~> 1.0)
@@ -370,8 +406,11 @@ GEM
       omniauth (~> 1.2)
     orm_adapter (0.5.0)
     os (0.9.6)
+    parser (2.4.0.0)
+      ast (~> 2.2)
     parslet (1.7.1)
       blankslate (>= 2.0, <= 4.0)
+    powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -402,6 +441,10 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.2)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.1)
+      actionpack (~> 5.x)
+      actionview (~> 5.x)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.2)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6)
@@ -415,7 +458,11 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.2.1)
     rake (12.0.0)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.8)
+      ffi (>= 0.5.0)
     rb-readline (0.5.4)
     rdf (2.2.3)
       hamster (~> 3.0)
@@ -462,12 +509,20 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    rubocop (0.34.2)
+      astrolabe (~> 1.3)
+      parser (>= 2.2.2.5, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.4)
+    rubocop-rspec (1.3.1)
     ruby-box (1.15.0)
       addressable
       json
       multipart-post
       oauth2
     ruby-progressbar (1.8.1)
+    ruby_dep (1.5.0)
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.4.23)
@@ -480,6 +535,7 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    shellany (0.0.1)
     signet (0.7.3)
       addressable (~> 2.3)
       faraday (~> 0.9)
@@ -579,7 +635,10 @@ DEPENDENCIES
   curation_concerns (~> 1.6.3)
   devise
   devise-guests (~> 0.3)
+  factory_girl_rails
   fcrepo_wrapper
+  guard-rspec
+  guard-rubocop
   jbuilder (~> 2.0)
   jquery-rails
   omniauth-cas
@@ -587,12 +646,16 @@ DEPENDENCIES
   pry-nav
   pry-rails
   rails (~> 5.0.0, >= 5.0.0.1)
+  rails-controller-testing
   rb-readline
   rsolr (~> 1.0)
   rspec
   rspec-rails
+  rubocop (~> 0.34.0)
+  rubocop-rspec (~> 1.3.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  simplecov
   solr_wrapper
   spring
   sqlite3
@@ -603,4 +666,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.4
+   1.14.5

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,77 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+## Uncomment and set this to only include directories you want to watch
+# directories %w(app lib config test spec features) \
+#  .select{|d| Dir.exists?(d) ? d : UI.warning("Directory #{d} does not exist")}
+
+## Note: if you are using the `directories` clause above and you are not
+## watching the project directory ('.'), then you will want to move
+## the Guardfile to a watched dir and symlink it back, e.g.
+#
+#  $ mkdir config
+#  $ mv Guardfile config/
+#  $ ln -s config/Guardfile .
+#
+# and, you'll have to watch "config/Guardfile" instead of "Guardfile"
+
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
+#  * 'just' rspec: 'rspec'
+
+group :red_green_refactor, halt_on_fail: true do
+  guard :rspec, cmd: "bundle exec rspec -f doc" do
+    require "guard/rspec/dsl"
+    dsl = Guard::RSpec::Dsl.new(self)
+  
+    # Feel free to open issues for suggestions and improvements
+  
+    # RSpec files
+    rspec = dsl.rspec
+    watch(rspec.spec_helper) { rspec.spec_dir }
+    watch(rspec.spec_support) { rspec.spec_dir }
+    watch(rspec.spec_files)
+  
+    # Ruby files
+    ruby = dsl.ruby
+    dsl.watch_spec_files_for(ruby.lib_files)
+  
+    # Rails files
+    rails = dsl.rails(view_extensions: %w(erb haml slim))
+    dsl.watch_spec_files_for(rails.app_files)
+    dsl.watch_spec_files_for(rails.views)
+  
+    watch(rails.controllers) do |m|
+      [
+        rspec.spec.call("routing/#{m[1]}_routing"),
+        rspec.spec.call("controllers/#{m[1]}_controller"),
+        rspec.spec.call("acceptance/#{m[1]}")
+      ]
+    end
+  
+    # Rails config changes
+    watch(rails.spec_helper)     { rspec.spec_dir }
+    watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
+    watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+  
+    # Capybara features specs
+    watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
+    watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+  
+    # Turnip features and steps
+    watch(%r{^spec/acceptance/(.+)\.feature$})
+    watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
+      Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
+    end
+  end
+  
+  guard :rubocop do
+    watch(%r{.+\.rb$})
+    watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
+  end
+end

--- a/spec/controllers/curation_concerns/file_sets_controller_spec.rb
+++ b/spec/controllers/curation_concerns/file_sets_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe CurationConcerns::FileSetsController do
+  let(:file_set) { FactoryGirl.build(:file_set, user: user) }
+  let(:user) { FactoryGirl.create(:user) }
+  render_views
+
+  describe "#show" do
+    before do
+      sign_in user
+      file_set.save!
+    end
+    it "renders :show" do
+      get :show, params: { id: file_set.id }
+      expect(response).to render_template :show
+    end
+  end
+
+  describe "#edit" do
+    before do
+      sign_in user
+      file_set.save!
+    end
+    it "renders :edit" do
+      get :edit, params: { id: file_set.id }
+      expect(response).to render_template :edit
+    end
+  end
+end

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -1,0 +1,18 @@
+FactoryGirl.define do
+  factory :file_set, class: FileSet do
+    transient do
+      user { FactoryGirl.create(:user) }
+      content nil
+    end
+
+    after(:create) do |file, evaluator|
+      if evaluator.content
+        Hydra::Works::UploadFileToFileSet.call(file, evaluator.content)
+      end
+    end
+
+    after(:build) do |file, evaluator|
+      file.apply_depositor_metadata(evaluator.user.user_key)
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :user do
+    sequence(:email) { |n| "email-#{srand}@test.com" }
+    sequence(:password) { |n| "password#{n}" }
+    provider 'cas'
+    uid do |user|
+      user.email
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,10 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'capybara/rspec'
+require 'capybara/rails'
+require 'rails-controller-testing'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
Adds controller tests for the 2 actions that were recently broken (#show, #edit), and some spec-related gems.  Various notes:
 * On the tests:
   * Rather than standalone view tests, I usually just put a `render_views` call in my controller tests, because verifying the view renders is all the view spec'ing out that I'm inclined to do.  But if other folks strongly prefer that we follow another pattern, please comment.
 * On the gems:
   * **factory_girl_rails**: For building test models; could be dropped, if folks prefer another approach
   * **guard**: For automated running of specs, rubocop compliance; no one _has_ to use it, but _I_ like to, so I'd like to include it
   * **rails-controller-testing**: For Rails 5, provides access to a couple of rspec methods that were moved into this; this was necessary for the render_template checks
   * **rubocop**: For formatting, syntax compliance;  
   * **simplecov**: For local test coverage reports; again, no one _has_ to use it, but I like to have the option of looking at it
 * On configuration:
   * The Guardfile is currently configured to run rubocop checks along with specs -- but we have a _massive_ set of rubocop violations, so we might want to turn that off if we don't plan on fixing/escaping them.