### PR TITLE
[HDM-1104] Fix broken indexing line

### DIFF
--- a/app/models/concerns/file_set_behavior.rb
+++ b/app/models/concerns/file_set_behavior.rb
@@ -28,7 +28,7 @@ module Concerns
       end
 
       property :format_file_size, predicate: RDF::Vocab::EBUCore.fileSize, multiple: false do |index|
-        index.as :long, :stored, :searchable, :sortable
+        index.as :stored_searchable, :stored_sortable
       end
 
       property :identifier, predicate: RDF::Vocab::EBUCore.identifier, multiple: false do |index|


### PR DESCRIPTION
Was this not broken for anyone else?  Locally, when I try to save an existing (valid) FileSet, I get:
```
Solrizer::UnknownIndexMacro: Unable to find `long' in [Solrizer::DefaultDescriptors]
from /home/aploshay/.rvm/gems/ruby-2.3.4/gems/solrizer-3.4.1/lib/solrizer/field_mapper.rb:140:in `index_type_macro'
```