### PR TITLE
Specifies Solr v6.6.1 in SolrWrapper config

### DIFF
--- a/.solr_wrapper.development.yml
+++ b/.solr_wrapper.development.yml
@@ -1,5 +1,5 @@
 # Place any default configuration for solr_wrapper here
-# version: 6.0.0
+version: 6.6.1
 # port: 8983
 instance_dir: tmp/solr-development
 collection:

--- a/.solr_wrapper.production.yml
+++ b/.solr_wrapper.production.yml
@@ -1,6 +1,6 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
-verion: 6.6.1
+version: 6.6.1
 collection:
   dir: solr/config/
   name: phydo-production

--- a/.solr_wrapper.production.yml
+++ b/.solr_wrapper.production.yml
@@ -1,5 +1,6 @@
 # Place any default configuration for solr_wrapper here
 # port: 8983
+verion: 6.6.1
 collection:
   dir: solr/config/
   name: phydo-production

--- a/.solr_wrapper.test.yml
+++ b/.solr_wrapper.test.yml
@@ -1,5 +1,6 @@
 # Place any default configuration for solr_wrapper here
 port: 8985
+version: 6.6.1
 collection:
   dir: solr/config/
   name: phydo-test


### PR DESCRIPTION
The latest version of solr_wrapper defaults to Solr v7.x, however Hyrax ships
with a default Solr schema that is not compatible with Solr 7. Eventually we
want to update the Solr schema to be compat with Solr 7, but this is easier for
now. Note that it only works becaue our Solr instance *only* comes from
solr_wrapper gem at this point.