### PR TITLE
[HDM-1172] Override stock user utility links view for login

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,8 +14,8 @@ class User < ActiveRecord::Base
   include Blacklight::User
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable,
+  devise :database_authenticatable,
+         :rememberable, :trackable, :validatable,
          :omniauthable, :omniauth_providers => [:cas]
 
   # Method added by Blacklight; Blacklight uses #to_s on your

--- a/app/presenters/phydo/file_set_presenter.rb
+++ b/app/presenters/phydo/file_set_presenter.rb
@@ -29,7 +29,7 @@ module Phydo
     end
 
     def deaccessioned?
-      @solr_document.recent_preservation_events.select { |e| e['premis_event_type_ssim'].first == 'dea' && e['premis_event_outcome_tesim'].first.match(/(succ|pass)/i) }.any?
+      @solr_document.recent_preservation_events.select { |e| e['premis_event_type_ssim']&.first == 'dea' && e['premis_event_outcome_tesim']&.first.to_s.match(/(succ|pass)/i) }.any?
     end
   end
 end

--- a/app/views/_user_util_links.html.erb
+++ b/app/views/_user_util_links.html.erb
@@ -1,0 +1,40 @@
+<ul id="user_utility_links" class="nav navbar-nav navbar-right">
+    <%= render 'shared/locale_picker' if available_translations.size > 1 %>
+    <% if user_signed_in? %>
+    <li>
+      <%= link_to hyrax.notifications_path do %>
+        <%= t("hyrax.toolbar.notifications") %>
+        <%= render 'hyrax/users/notify_number' %>
+      <% end %>
+    </li>
+    <li class="dropdown">
+      <%= link_to hyrax.profile_path(current_user), role: 'button', data: { toggle: 'dropdown' }, aria: { haspopup: true, expanded: false} do %>
+        <span class="sr-only"><%= t("hyrax.toolbar.profile.sr_action") %></span>
+        <span class="hidden-xs">&nbsp;<%= current_user.name %></span>
+        <span class="sr-only"> <%= t("hyrax.toolbar.profile.sr_target") %></span>
+        <span class="fa fa-user"></span>
+        <span class="caret"></span>
+      <% end %>
+      <ul class="dropdown-menu dropdown-menu-right" role="menu">
+        <li><%= link_to t("hyrax.toolbar.profile.view"), hyrax.profile_path(current_user) %></li>
+        <li><%= link_to t("hyrax.toolbar.profile.edit"), hyrax.edit_profile_path(current_user) %></li>
+        <li class="divider"></li>
+        <li><%= link_to t("hyrax.toolbar.profile.logout"), main_app.destroy_user_session_path %></li>
+      </ul>
+    </li><!-- /.btn-group -->
+  <% elsif User.omniauth_providers.any? %>
+    <%- User.omniauth_providers.each do |provider| %> 
+      <li>
+        <%= link_to omniauth_authorize_path('user', provider) do %>
+          <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span > <%= t("hyrax.toolbar.profile.login") + ' with ' + OmniAuth::Utils.camelize(provider) %>
+        <% end %>
+      </li>
+    <% end -%>
+  <% else %>
+    <li>
+      <%= link_to main_app.new_user_session_path do %>
+        <span class="glyphicon glyphicon-log-in" aria-hidden="true"></span > <%= t("hyrax.toolbar.profile.login") %>
+      <% end %>
+    </li>
+  <% end %>
+</ul>


### PR DESCRIPTION
Imports and modifies the stock hyrax partial:
https://github.com/samvera/hyrax/blob/master/app/views/_user_util_links.html.erb
The modification is adding the `elsif` block (lines 25-32) that provides links to login by (a) specific authentication method(s), bypassing the generic login page that allowed creating a local account.